### PR TITLE
feat: connection status updates

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -81,6 +81,12 @@ const App: React.FC = () => {
           dispatch({ type: ActionType.ConnectToBridge, name })
           const connection = await (window as any).bridgeManagerService.connectToBridge({ name, retries: -1 })
           dispatch({ type: ActionType.ConnectToBridgeSuccess, connection })
+
+          // After connection, register callback for connection streaming stuff
+          ;(window as any).deviceManagerService.connectionStatusStream(
+            { name, enableStream: true },
+            ({ message, name }: { message: string, name: string }) => dispatch({ type: ActionType.ConnectionStatusUpdate, message, name })
+          )
         } catch (e) {
           dispatch({ type: ActionType.ConnectToBridgeFailure, message: e.message, name })
         }

--- a/tests/renderer/util/OmniContext.test.tsx
+++ b/tests/renderer/util/OmniContext.test.tsx
@@ -393,4 +393,54 @@ describe('omniReducer', () => {
       expect(left.previousState).toBe(ConnectionState.ConnectedDevice)
     })
   })
+
+  describe("ConnectionStatusUpdate", () => {
+    it("transitions to disconnected when the CTM sends a disconnect update", () => {
+      let { left, right } = initState
+
+      left.connectionState = ConnectionState.ConnectedDevice
+      left.previousState = ConnectionState.ConnectingDevice
+
+      const message = 'CTM Disconnected!'
+      ;({ left, right } = omniReducer(initState, { type: ActionType.ConnectionStatusUpdate, message, name: left.name }))
+
+      expect(left.connectionState).toBe(ConnectionState.Disconnected)
+      expect(left.previousState).toBe(ConnectionState.ConnectedDevice)
+
+      expect(right.connectionState).toBe(ConnectionState.ConnectedBridge)
+      expect(right.previousState).toBe(ConnectionState.ConnectingBridge)
+    })
+
+    it("transitions to connected-bridge when the CTM sends a connection update", () => {
+      let { left, right } = initState
+
+      left.connectionState = ConnectionState.Disconnected
+      left.previousState = ConnectionState.ConnectedDevice
+
+      const message = 'CTM Connected!'
+      ;({ left, right } = omniReducer(initState, { type: ActionType.ConnectionStatusUpdate, message, name: left.name }))
+
+      expect(left.connectionState).toBe(ConnectionState.ConnectedBridge)
+      expect(left.previousState).toBe(ConnectionState.Disconnected)
+
+      expect(right.connectionState).toBe(ConnectionState.ConnectedBridge)
+      expect(right.previousState).toBe(ConnectionState.ConnectingBridge)
+    })
+
+    it('transitions to error-bridge when any other message is sent', () => {
+      let { left, right } = initState
+
+      left.connectionState = ConnectionState.ConnectedDevice
+      left.previousState = ConnectionState.ConnectingDevice
+
+      const message = 'unhandled status update message'
+      ;({ left, right } = omniReducer(initState, { type: ActionType.ConnectionStatusUpdate, message, name: left.name }))
+
+      expect(left.connectionState).toBe(ConnectionState.ErrorBridge)
+      expect(left.previousState).toBe(ConnectionState.ConnectedDevice)
+
+      expect(right.connectionState).toBe(ConnectionState.ConnectedBridge)
+      expect(right.previousState).toBe(ConnectionState.ConnectingBridge)
+    })
+  })
 })


### PR DESCRIPTION
This commit introduces connection status event handlers and associated state management. Note that the backend code does not try to reconnect the INS at this time