### PR TITLE
fix: remove status stream

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -103,14 +103,6 @@ const App: React.FC = () => {
           dispatch({ type: ActionType.ConnectToBridge, name })
           const connection = await (window as any).bridgeManagerService.connectToBridge({ name, retries: -1 })
           dispatch({ type: ActionType.ConnectToBridgeSuccess, connection })
-
-          // After connection, register callback for connection streaming stuff
-          ;(window as any).bridgeManagerService.connectionStatusStream(
-            { name, enableStream: true },
-            ({ connectionStatus: message, name }: {connectionStatus: string, name: string}) => {
-              dispatch({ type: ActionType.ConnectionStatusUpdate, message, name })
-            }
-          )
         } catch (e) {
           dispatch({ type: ActionType.ConnectToBridgeFailure, message: e.message, name })
         }

--- a/src/renderer/util/OmniContext.tsx
+++ b/src/renderer/util/OmniContext.tsx
@@ -46,7 +46,6 @@ export enum ActionType {
   ConnectToBridge = 'connect-to-bridge',
   ConnectToBridgeSuccess = 'connect-to-bridge-success',
   ConnectToBridgeFailure = 'connect-to-bridge-failure',
-  ConnectionStatusUpdate = 'connection-status-update',
   DisconnectFromBridge = 'disconnect-from-bridge',
   BatteryBridge = 'battery-bridge',
   BatteryBridgeSuccess = 'battery-bridge-success',
@@ -73,7 +72,6 @@ export type Action =
   | { type: ActionType.ConnectToBridge, name: string}
   | { type: ActionType.ConnectToBridgeSuccess, connection: {name: string, connectionStatus: string, details: any}}
   | { type: ActionType.ConnectToBridgeFailure, message: string, name: string }
-  | { type: ActionType.ConnectionStatusUpdate, message: string, name: string }
   | { type: ActionType.DisconnectFromBridge, name: string, error?: string }
   | { type: ActionType.BatteryBridge, name: string }
   | { type: ActionType.BatteryBridgeSuccess, response: {details: any, error: any}, name: string }
@@ -273,32 +271,6 @@ export const omniReducer = (state: State, action: Action) => {
         item.previousState = item.connectionState
         item.connectionState = ConnectionState.ErrorBridge
         item.error = message
-      })
-
-      return { left, right }
-    }
-    case ActionType.ConnectionStatusUpdate: {
-      const { message, name } = action
-
-      ;[left, right].forEach(item => {
-        if (!item.name.startsWith(name)) { return }
-
-        item.previousState = item.connectionState
-
-        switch (message) {
-          case 'CTM Disconnected!':
-          case 'CTM Disposed!':
-          case 'CTM Connection Failed!':
-          case 'CTM Retry Failed!':
-            item.connectionState = ConnectionState.Disconnected
-            break
-          case 'CTM Connected!':
-            item.connectionState = ConnectionState.ConnectedBridge
-            break
-          default:
-            item.connectionState = ConnectionState.ErrorBridge
-            break
-        }
       })
 
       return { left, right }

--- a/tests/renderer/util/OmniContext.test.tsx
+++ b/tests/renderer/util/OmniContext.test.tsx
@@ -398,56 +398,6 @@ describe('omniReducer', () => {
     })
   })
 
-  describe("ConnectionStatusUpdate", () => {
-    it("transitions to disconnected when the CTM sends a disconnect update", () => {
-      let { left, right } = initState
-
-      left.connectionState = ConnectionState.ConnectedDevice
-      left.previousState = ConnectionState.ConnectingDevice
-
-      const message = 'CTM Disconnected!'
-      ;({ left, right } = omniReducer(initState, { type: ActionType.ConnectionStatusUpdate, message, name: left.name }))
-
-      expect(left.connectionState).toBe(ConnectionState.Disconnected)
-      expect(left.previousState).toBe(ConnectionState.ConnectedDevice)
-
-      expect(right.connectionState).toBe(ConnectionState.ConnectedBridge)
-      expect(right.previousState).toBe(ConnectionState.ConnectingBridge)
-    })
-
-    it("transitions to connected-bridge when the CTM sends a connection update", () => {
-      let { left, right } = initState
-
-      left.connectionState = ConnectionState.Disconnected
-      left.previousState = ConnectionState.ConnectedDevice
-
-      const message = 'CTM Connected!'
-      ;({ left, right } = omniReducer(initState, { type: ActionType.ConnectionStatusUpdate, message, name: left.name }))
-
-      expect(left.connectionState).toBe(ConnectionState.ConnectedBridge)
-      expect(left.previousState).toBe(ConnectionState.Disconnected)
-
-      expect(right.connectionState).toBe(ConnectionState.ConnectedBridge)
-      expect(right.previousState).toBe(ConnectionState.ConnectingBridge)
-    })
-
-    it('transitions to error-bridge when any other message is sent', () => {
-      let { left, right } = initState
-
-      left.connectionState = ConnectionState.ConnectedDevice
-      left.previousState = ConnectionState.ConnectingDevice
-
-      const message = 'unhandled status update message'
-      ;({ left, right } = omniReducer(initState, { type: ActionType.ConnectionStatusUpdate, message, name: left.name }))
-
-      expect(left.connectionState).toBe(ConnectionState.ErrorBridge)
-      expect(left.previousState).toBe(ConnectionState.ConnectedDevice)
-
-      expect(right.connectionState).toBe(ConnectionState.ConnectedBridge)
-      expect(right.previousState).toBe(ConnectionState.ConnectingBridge)
-    })
-  })
-
   describe('BatteryBridge', () => {
     it('does nothing when initiated', () => {
       const { left } = initState


### PR DESCRIPTION
Remove the connection status stream. Connection status will be gathered through polling the `DescribeBridge` endpoint