### PR TITLE
feat: absolute directory for config files for autoupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,8 @@ npm run lint -- --fix
 ```
 ## Configuration files
 
-In the packaged version of the app, the sensing config files will not be bundled with the app and needs to be copied into this directory on windows: `/AppData/Roaming/omniconfig`. 
+In the packaged version of the app, the sensing config files will not be bundled with the app and needs to be copied into this directory on windows: `/AppData/Roaming/omniconfig`. Examples of these files can be found in the `config` folder of this repository.
+
+- `config.json` - main config file, the `name` field of the left and right objects need to be updated with the serial number of both the CTM and the INS: "//summit/bridge/<CTM serial number>/device/<INS serial number>".
+- `senseLeft_config.json` - sensing config for the left INS, make sure that this file is in the same directory as `config.json`.
+- `senseRight_config.json` - sensing config for the right INS, make sure that this file is in the same directory as `config.json`.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ To have the linter fix errors, run:
 ```
 npm run lint -- --fix
 ```
+## Configuration files
+
+In the packaged version of the app, the sensing config files will not be bundled with the app and needs to be copied into this directory on windows: `/AppData/Roaming/omniconfig`. 

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,5 @@
 {
-  "serverAddress": "192.168.0.106:50051",
+  "serverAddress": "localhost:50051",
   "left": {
     "name": "//summit/bridge/NKW005449N/device/NPC700365H",
     "configPath": "./senseLeft_config.json"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omniclient",
   "productName": "omniclient",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "My Electron application description",
   "main": ".webpack/main",
   "private": true,
@@ -25,8 +25,7 @@
     "forge": {
       "packagerConfig": {
         "extraResource": [
-          "./protos",
-          "./config"
+          "./protos"
         ]
       },
       "makers": [

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,7 +70,8 @@ app.on('activate', () => {
   }
 })
 
-const CONFIG_DIR = isDevelopment ? path.join(__dirname, '../../config') : path.join(__dirname, '../../../config')
+// Absolute path for configs -> /AppData/Local/omniconfig
+const CONFIG_DIR = isDevelopment ? path.join(__dirname, '../../config') : path.join(app.getPath('home'), 'AppData/Local/omniconfig')
 const config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, 'config.json'), 'utf-8'))
 config.left.config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, config.left.configPath), 'utf-8'))
 config.right.config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, config.right.configPath), 'utf-8'))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,8 +70,8 @@ app.on('activate', () => {
   }
 })
 
-// Absolute path for configs -> /AppData/Local/omniconfig
-const CONFIG_DIR = isDevelopment ? path.join(__dirname, '../../config') : path.join(app.getPath('home'), 'AppData/Local/omniconfig')
+// Absolute path for configs on windows-> /AppData/Roaming/omniconfig
+const CONFIG_DIR = isDevelopment ? path.join(__dirname, '../../config') : path.join(app.getPath('appData'), 'omniconfig')
 const config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, 'config.json'), 'utf-8'))
 config.left.config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, config.left.configPath), 'utf-8'))
 config.right.config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, config.right.configPath), 'utf-8'))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,7 +21,8 @@ if (require('electron-squirrel-startup') === undefined) { // eslint-disable-line
 
 // Auto update
 require('update-electron-app')({
-  repo: 'brown-ccv/OmniReferenceClient'
+  repo: 'brown-ccv/OmniReferenceClient',
+  updateInterval: '1 hour'
 })
 
 // TODO: https://stackoverflow.com/questions/52236641/electron-ipc-and-nodeintegration


### PR DESCRIPTION
The current behavior of auto-update is to create a new version directory, which includes the default configuration packaged with the app. Under this system, the user will have to copy over the config files every time the auto-update triggers, which is not desirable. Setting the directory as absolute can fix this, so every app, no matter the version, will extract the config from that directory.

A few concerns -
- Where should we create that directory, in this PR it's under `AppData/Roaming/omniconfig`
- How is the config files packaged? Will just redefining `CONFIG_DIR` copy over the default config to that directory?
- How should we handle the case where the config file is not found? Should we prevent the app from launching or use a 
default config and alert the user?