### PR TITLE
feat: basic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ In the packaged version of the app, the sensing config files will not be bundled
 - `config.json` - main config file, the `name` field of the left and right objects need to be updated with the serial number of both the CTM and the INS: "//summit/bridge/<CTM serial number>/device/<INS serial number>".
 - `senseLeft_config.json` - sensing config for the left INS, make sure that this file is in the same directory as `config.json`.
 - `senseRight_config.json` - sensing config for the right INS, make sure that this file is in the same directory as `config.json`.
+
+## Logging
+
+There are very simple logs contained in `%USERPROFILE%\AppData\Roaming\{app name}\logs\{process type}.log`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniclient",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "omniclient",
-      "version": "2.2.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
@@ -15,6 +15,7 @@
         "@grpc/grpc-js": "^1.3.0",
         "@grpc/proto-loader": "^0.6.1",
         "bulma": "^0.9.2",
+        "electron-log": "^4.3.5",
         "electron-squirrel-startup": "^1.0.0",
         "execa": "^5.1.1",
         "node-sass": "^6.0.0",
@@ -5200,6 +5201,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
       "integrity": "sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4="
+    },
+    "node_modules/electron-log": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.3.5.tgz",
+      "integrity": "sha512-J5Ew3axdk7W4jzzxKLSAi1sqbcAoo9CzHuBVsG0tT47j256xKulNrWFf3lZmHJ1KDXOQUcuwOngQF0jjmpEdpw=="
     },
     "node_modules/electron-notarize": {
       "version": "1.0.0",
@@ -21582,6 +21588,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
       "integrity": "sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4="
+    },
+    "electron-log": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.3.5.tgz",
+      "integrity": "sha512-J5Ew3axdk7W4jzzxKLSAi1sqbcAoo9CzHuBVsG0tT47j256xKulNrWFf3lZmHJ1KDXOQUcuwOngQF0jjmpEdpw=="
     },
     "electron-notarize": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@grpc/grpc-js": "^1.3.0",
     "@grpc/proto-loader": "^0.6.1",
     "bulma": "^0.9.2",
+    "electron-log": "^4.3.5",
     "electron-squirrel-startup": "^1.0.0",
     "execa": "^5.1.1",
     "node-sass": "^6.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,13 @@
 import * as path from 'path'
 import * as fs from 'fs'
+import { inspect } from 'util'
 
 import * as grpc from '@grpc/grpc-js'
 import * as protoLoader from '@grpc/proto-loader'
 import * as protobufjs from 'protobufjs'
 
 import execa from 'execa'
+import log, { info } from 'electron-log'
 
 import { app, BrowserWindow, ipcMain } from 'electron'
 
@@ -13,6 +15,8 @@ declare const MAIN_WINDOW_WEBPACK_ENTRY: string
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
+
+log.info('main process start')
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup') === undefined) { // eslint-disable-line global-require
@@ -105,187 +109,298 @@ const parseAny = (message: any) => {
 }
 
 ipcMain.handle('list-bridges', async (event, request: any) => {
+  const logScope = log.scope('list-bridges')
+  logScope.info('recieved list-bridges')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     bridgeClient.listBridges(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
+
+      logScope.info(`response ${inspect(resp)}`)
       return resolve(resp)
     })
   })
 })
 
 ipcMain.handle('connect-to-bridge', async (event, request) => {
+  const logScope = log.scope('connect-to-bridge')
+  logScope.info('recieved connect-to-bridge')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     bridgeClient.ConnectBridge(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
-      const details = parseAny(resp.details)
-      return resolve({ ...resp, details })
-    })
-  })
-})
-
-ipcMain.handle('connected-bridges', async (event, request) => {
-  return await new Promise((resolve, reject) => {
-    bridgeClient.ConnectedBridges(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
-      return resolve(resp)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
+      const response = {...resp, details: parseAny(resp.details)}
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('describe-bridge', async (event, request) => {
+  const logScope = log.scope('describe-bridge')
+  logScope.info('recieved describe-bridge')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     bridgeClient.DescribeBridge(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const details = parseAny(resp.details)
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, details, error })
+      const response = {...resp,
+        details: parseAny(resp.details),
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('disconnect-from-bridge', async (event, request) => {
+  const logScope = log.scope('disconnect-from-bridge')
+  logScope.info('recieved disconnect-from-bridge')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     bridgeClient.DisconnectBridge(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
+
+      logScope.info(`response ${inspect(resp)}`)
       return resolve(resp)
     })
   })
 })
 
-ipcMain.on('connection-status-stream', async (event, request) => {
-  const call = bridgeClient.connectionStatusStream(request)
-
-  call.on('data', (resp: any) => {
-    event.reply('connection-update', resp)
-  })
-
-  call.on('end', () => {
-    call.removeAllListeners('data')
-  })
-
-  call.on('error', (err: Error) => {
-    // TODO (BNR): How do we handle errors at this level?
-    console.error(err)
-    call.removeAllListeners('data')
-  })
-})
-
 ipcMain.handle('list-devices', async (event, request) => {
+  const logScope = log.scope('list-devices')
+  logScope.info('recieved list-devices')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.ListDevices(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, error })
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
+
+      const response = {...resp, error: parseAny(resp.error)}
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('connect-to-device', async (event, request) => {
+  const logScope = log.scope('connect-to-device')
+  logScope.info('recieved connect-to-device')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.ConnectDevice(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const details = parseAny(resp.details)
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, details, error })
+      const response = {
+        ...resp,
+        details: parseAny(resp.details),
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('disconnect-from-device', async (event, request) => {
+  const logScope = log.scope('disconnect-from-device')
+  logScope.info('recieved disconnect-from-device')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.DisconnectDevice(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
+
+      logScope.info(`response ${inspect(resp)}`)
       return resolve(resp)
     })
   })
 })
 
 ipcMain.handle('device-status', async (event, request) => {
+  const logScope = log.scope('device-status')
+  logScope.info('recieved device-status')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.DeviceStatus(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const details = parseAny(resp.details)
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, details, error })
+      const response = {
+        ...resp,
+        details: parseAny(resp.details),
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('sense-configuration', async (event, request) => {
+  const logScope = log.scope('sense-configuration')
+  logScope.info('recieved sense-configuration')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.SenseConfiguration(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, error })
+      const response = {
+        ...resp,
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('stream-enable', async (event, request) => {
+  const logScope = log.scope('stream-enable')
+  logScope.info('recieved stream-enable')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.StreamEnable(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, error })
+      const response = {
+        ...resp,
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('stream-disable', async (event, request) => {
+  const logScope = log.scope('stream-disable')
+  logScope.info('recieved stream-disable')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.StreamDisable(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, error })
+      const response = {
+        ...resp,
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('integrity-test', async (event, request) => {
+  const logScope = log.scope('integrity-test')
+  logScope.info('recieved integrity-test')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     deviceClient.LeadIntegrityTest(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, error })
+      const response = {
+        ...resp,
+        error: parseAny(resp.error)
+      }
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 ipcMain.handle('configure-beep', async (event, request) => {
+  const logScope = log.scope('configure-beep')
+  logScope.info('recieved configure-beep')
+  logScope.info(`request ${inspect(request)}`)
   return await new Promise((resolve, reject) => {
     bridgeClient.ConfigureBeep(request, (err: Error, resp: any) => {
-      if (err) return reject(err)
+      logScope.debug('in callback')
+      if (err) {
+        logScope.error(err)
+        return reject(err)
+      }
 
-      const error = parseAny(resp.error)
-      return resolve({ ...resp, error })
+      const response = {...resp, error: parseAny(resp.error)}
+      logScope.info(`response ${inspect(response)}`)
+      return resolve(response)
     })
   })
 })
 
 // Function to launch jsPsych tasks
 ipcMain.on('task-launch', (event, { appDir }) => {
+  const logScope = log.scope('task-launch')
+  logScope.info('recieved task-launch')
+  logScope.info(`request ${inspect(appDir)}`)
   const home = app.getPath('home')
   // Path to tasks - /AppData/Local/<appDir>
   const fullPath = path.join(home, 'AppData', 'Local', appDir)
 
   if (fullPath === null) {
+    logScope.error(`need an app name: ${fullPath}`)
     throw new Error('need an app name')
   }
 
+  logScope.info(`opening ${fullPath}`)
   execa(fullPath).stdout?.pipe(process.stdout)
 })
 
 ipcMain.on('quit', (event, args) => {
+  const logScope = log.scope('quit')
+  logScope.info('recieved quit')
+  logScope.info('quitting')
   app.quit()
 })
 
 ipcMain.on('config', (event) => {
+  const logScope = log.scope('config')
+  logScope.info('recieved config')
   event.returnValue = config
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,27 +19,12 @@ contextBridge.exposeInMainWorld('bridgeManagerService', {
     return await ipcRenderer.invoke('connect-to-bridge', request)
   },
 
-  connectedBridges: async (request: any): Promise<any> => {
-    return await ipcRenderer.invoke('connected-bridges', request)
-  },
-
   describeBridge: async (request: any): Promise<any> => {
     return await ipcRenderer.invoke('describe-bridge', request)
   },
 
   disconnectFromBridge: async (request: any): Promise<void> => {
     return await ipcRenderer.invoke('disconnect-from-bridge', request)
-  },
-
-  connectionStatusStream: (request: any, callback: Function): void => {
-    const { enableStream } = request
-    if (enableStream) {
-      ipcRenderer.send('connection-status-stream', request)
-      ipcRenderer.on('connection-update', (_, resp) => callback(resp))
-    } else {
-      ipcRenderer.send('connection-status-stream', request)
-      ipcRenderer.removeAllListeners('connection-update')
-    }
   },
 
   configureBeep: async (request: any): Promise<any> => {


### PR DESCRIPTION
This commit introduces basic logging of the requests and responses from any commands the renderer process sends to the main process. The logs live here for windows:

```
%USERPROFILE%\AppData\Roaming\{app name}\logs\{process type}.log
```

In dev mode they print to the console and it's been working OK. We'll have to see how fast they fill up later. Close #80 