### PR TITLE
fix: add npm module to edit package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
       [
         "@semantic-release/github",
         {


### PR DESCRIPTION
It seems like from what I read in this thread: https://github.com/semantic-release/semantic-release/issues/1593, npm is needed after all since that is the module that is editing package.json