### PR TITLE
fix: separate bump version and release workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,18 @@
+name: Bump Version
+on:
+  push:
+    branches:
+      - main
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name:  'Automated Version Bump'
+        uses:  'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          skip-tag:  'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,12 @@
 name: Package Electron
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Bump Version"]
+    types: [completed]
 jobs:
   release:
     runs-on: windows-2019
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "summit-rcs",
   "productName": "summit-rcs",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "My Electron application description",
   "main": ".webpack/main",
   "private": true,
@@ -76,9 +76,7 @@
     "@electron-forge/plugin-webpack": "6.0.0-beta.54",
     "@marshallofsound/webpack-asset-relocator-loader": "^0.5.0",
     "@semantic-release/commit-analyzer": "^8.0.1",
-    "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.2.3",
-    "@semantic-release/npm": "^7.1.3",
     "@semantic-release/release-notes-generator": "^9.0.3",
     "@types/jest": "^26.0.23",
     "@types/react": "^17.0.5",
@@ -127,16 +125,6 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ],
       [
         "@semantic-release/github",
         {


### PR DESCRIPTION
This should fix the version desync, I tested this on my own repository. Having the two steps in the same workflow doesn't work since sem-release will give an error that the local branch is behind the remote branch because of the new commit.