### PR TITLE
Fix configure mode ratio

### DIFF
--- a/config/senseLeft_config.json
+++ b/config/senseLeft_config.json
@@ -4,15 +4,15 @@
 		"type": "Home streaming"
 	},
 	"Mode": 4,
-	"Ratio": 4,
+	"Ratio": 32,
 	"SenseOptions": {
 		"comment": "lets you set what to sense",
 		"TimeDomain": true,
 		"FFT": true,
 		"Power": true,
-		"LD0": true,
+		"LD0": false,
 		"LD1": false,
-		"AdaptiveState": true,
+		"AdaptiveState": false,
 		"LoopRecording": false,
 		"Unused": false
 	},
@@ -22,15 +22,15 @@
 		"FFT": false,
 		"Power": true,
 		"Accelerometry": true,
-		"AdaptiveTherapy": true,
-		"AdaptiveState": true,
-		"EventMarker": true,
+		"AdaptiveTherapy": false,
+		"AdaptiveState": false,
+		"EventMarker": false,
 		"TimeStamp": true
 	},
 	"Sense": {
 		"commentTDChannelDefinitions": "No more than two channels can be on a single bore. When configuring, channels on first bore will always be first. Can only have sampling rates of: 250, 500, and 1000 (Hz) or disable it by setting IsDisabled to true",
 		"commentFilters": "Stage one low pass(Lpf1) can only be: 450, 100, or 50 (Hz). Stage two low pass(Lpf2) can only be: 1700, 350, 160, or 100 (Hz). High pass(Hpf) can only be: 0.85, 1.2, 3.3, or 8.6 (Hz), Inputs[ anode(positive), cathode(negative) ], tdEvokedResponseEnable can either be 0 for standard, 16 for evoked 0 or 32 for evoked 1",
-		"TDSampleRate": 250,
+		"TDSampleRate": 1000,
 		"TimeDomains": [
 			{
 				"IsEnabled": true,
@@ -57,30 +57,30 @@
 			{
 				"IsEnabled": true,
 				"Hpf": 0.85,
-				"Lpf1": 450,
-				"Lpf2": 1700,
+				"Lpf1": 100,
+				"Lpf2": 100,
 				"Inputs": [
-					9,
-					10
+					8,
+					9
 				],
 				"TdEvokedResponseEnable": 0
 			},
 			{
 				"IsEnabled": true,
 				"Hpf": 0.85,
-				"Lpf1": 450,
-				"Lpf2": 1700,
+				"Lpf1": 100,
+				"Lpf2": 100,
 				"Inputs": [
-					8,
-					10
+					10,
+					11
 				],
 				"TdEvokedResponseEnable": 0
 			}
 		],
 		"FFT": {
 			"commentFFTParameters": "FFT Size can be: 64, 256, or 1024 samples, Hanning window load can be: 25, 50, or 100 (%), channel is for the fft channel must be between 0-3 and time domain must be enabled for that channel, WeightMultiplies can be shift: 0-7",
-			"Channel": 2,
-			"FftSize": 256,
+			"Channel": 1,
+			"FftSize": 1024,
 			"FftInterval": 100,
 			"WindowLoad": 100,
 			"StreamSizeBins": 0,
@@ -93,66 +93,66 @@
 			{
 				"comment": "Channel: 0 PowerBand: 0",
 				"ChannelPowerBand": [
-					17.09,
-					22.95
+					1,
+					5
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 0 PowerBand: 1",
 				"ChannelPowerBand": [
-					117.68,
-					121.58
+					5,
+					15
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 1 PowerBand: 0",
 				"ChannelPowerBand": [
-					123.54,
-					124.51
+					1,
+					5
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 1 PowerBand: 1",
 				"ChannelPowerBand": [
-					123.54,
-					124.51
+					5,
+					15
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 2 PowerBand: 0",
 				"ChannelPowerBand": [
-					8.3,
-					13.18
+					1,
+					5
 				],
-				"IsEnabled": false
+				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 2 PowerBand: 1",
 				"ChannelPowerBand": [
-					17.09,
-					22.95
+					5,
+					15
 				],
-				"IsEnabled": false
+				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 3 PowerBand: 0",
 				"ChannelPowerBand": [
-					8.3,
-					13.18
+					1,
+					5
 				],
-				"IsEnabled": false
+				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 3 PowerBand: 1",
 				"ChannelPowerBand": [
-					17.09,
-					22.95
+					5,
+					15
 				],
-				"IsEnabled": false
+				"IsEnabled": true
 			}
 		],
 		"Accelerometer": {

--- a/config/senseRight_config.json
+++ b/config/senseRight_config.json
@@ -8,8 +8,8 @@
 	"SenseOptions": {
 		"comment": "lets you set what to sense",
 		"TimeDomain": true,
-		"FFT": false,
-		"Power": false,
+		"FFT": true,
+		"Power": true,
 		"LD0": false,
 		"LD1": false,
 		"AdaptiveState": false,
@@ -20,7 +20,7 @@
 		"comment": "lets you set what to stream",
 		"TimeDomain": true,
 		"FFT": false,
-		"Power": false,
+		"Power": true,
 		"Accelerometry": true,
 		"AdaptiveTherapy": false,
 		"AdaptiveState": false,
@@ -30,12 +30,12 @@
 	"Sense": {
 		"commentTDChannelDefinitions": "No more than two channels can be on a single bore. When configuring, channels on first bore will always be first. Can only have sampling rates of: 250, 500, and 1000 (Hz) or disable it by setting IsDisabled to true",
 		"commentFilters": "Stage one low pass(Lpf1) can only be: 450, 100, or 50 (Hz). Stage two low pass(Lpf2) can only be: 1700, 350, 160, or 100 (Hz). High pass(Hpf) can only be: 0.85, 1.2, 3.3, or 8.6 (Hz), Inputs[ anode(positive), cathode(negative) ]",
-		"TDSampleRate": 250,
+		"TDSampleRate": 1000,
 		"TimeDomains": [
 			{
 				"IsEnabled": true,
 				"Hpf": 0.85,
-				"Lpf1": 450,
+				"Lpf1": 100,
 				"Lpf2": 100,
 				"Inputs": [
 					0,
@@ -44,9 +44,9 @@
 				"TdEvokedResponseEnable": false
 			},
 			{
-				"IsEnabled": false,
+				"IsEnabled": true,
 				"Hpf": 0.85,
-				"Lpf1": 450,
+				"Lpf1": 100,
 				"Lpf2": 100,
 				"Inputs": [
 					1,
@@ -57,30 +57,30 @@
 			{
 				"IsEnabled": true,
 				"Hpf": 0.85,
-				"Lpf1": 450,
+				"Lpf1": 100,
 				"Lpf2": 100,
 				"Inputs": [
-					0,
-					2
+					8,
+					9
 				],
 				"TdEvokedResponseEnable": false
 			},
 			{
-				"IsEnabled": false,
+				"IsEnabled": true,
 				"Hpf": 0.85,
-				"Lpf1": 450,
+				"Lpf1": 100,
 				"Lpf2": 100,
 				"Inputs": [
-					1,
-					3
+					10,
+					11
 				],
 				"TdEvokedResponseEnable": false
 			}
 		],
 		"FFT": {
 			"commentFFTParameters": "FFT Size can be: 64, 256, or 1024 samples, Hanning window load can be: 25, 50, or 100 (%), channel is for the fft channel must be between 0-3 and time domain must be enabled for that channel",
-			"Channel": 0,
-			"FftSize": 256,
+			"Channel": 1,
+			"FftSize": 1024,
 			"FftInterval": 100,
 			"WindowLoad": 100,
 			"StreamSizeBins": 0,
@@ -93,64 +93,64 @@
 			{
 				"comment": "Channel: 0 PowerBand: 0",
 				"ChannelPowerBand": [
-					0,
-					1
+					1,
+					5
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 0 PowerBand: 1",
 				"ChannelPowerBand": [
-					0,
-					1
+					5,
+					15
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 1 PowerBand: 0",
 				"ChannelPowerBand": [
-					0,
-					1
+					1,
+					5
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 1 PowerBand: 1",
 				"ChannelPowerBand": [
-					0,
-					1
+					5,
+					15
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 2 PowerBand: 0",
 				"ChannelPowerBand": [
-					0,
-					1
+					1,
+					5
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 2 PowerBand: 1",
 				"ChannelPowerBand": [
-					0,
-					1
+					5,
+					15
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 3 PowerBand: 0",
 				"ChannelPowerBand": [
-					0,
-					1
+					1,
+					5
 				],
 				"IsEnabled": true
 			},
 			{
 				"comment": "Channel: 3 PowerBand: 1",
 				"ChannelPowerBand": [
-					0,
-					1
+					5,
+					15
 				],
 				"IsEnabled": true
 			}
@@ -162,9 +162,9 @@
 		},
 		"Misc": {
 			"commentMiscParameters": "stream rate can be 30-100 by tens and is in ms; LoopRecordingTriggersState can be 0-8 or can be disabled by changing IsEnabled to false; Bridging can be 0 = None, 1 = Bridge 0-2 enabled, 2 = Bridge 1-3 enabled",
-			"StreamingRate": 60,
+			"StreamingRate": 100,
 			"LoopRecordingTriggersState": 0,
-			"LoopRecordingTriggersIsEnabled": false,
+			"LoopRecordingTriggersIsEnabled": true,
 			"LoopRecordingPostBufferTime": 53,
 			"Bridging": 0
 		}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -401,6 +401,9 @@ ipcMain.on('quit', (event, args) => {
 
 ipcMain.on('config', (event) => {
   const logScope = log.scope('config')
+  const config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, 'config.json'), 'utf-8'))
+  config.left.config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, config.left.configPath), 'utf-8'))
+  config.right.config = JSON.parse(fs.readFileSync(path.join(CONFIG_DIR, config.right.configPath), 'utf-8'))
   logScope.info('recieved config')
   event.returnValue = config
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -89,7 +89,24 @@ const App: React.FC = () => {
             console.group('ConnectToBridge')
             try {
               yield dispatch({ type: ActionType.ConnectToBridge, name })
-              const connection = await (window as any).bridgeManagerService.connectToBridge({ name })
+              const config = await (window as any).appService.config()
+              let telemetryMode, telemetryRatio
+              console.log(config)
+              if (name === config.left.name) {
+                telemetryMode = config.left.config.Mode
+                telemetryRatio = config.left.config.Ratio
+              } else {
+                telemetryMode = config.right.config.Mode
+                telemetryRatio = config.right.config.Ratio
+              }
+              const connection = await (window as any).bridgeManagerService.connectToBridge({
+                name,
+                parameters: {
+                  '@type': 'types.googleapis.com/openmind.SummitConnectBridgeParameters',
+                  telemetryMode: { value: telemetryMode },
+                  telemetryRatio: { value: telemetryRatio }, 
+                }
+              })
               console.log(connection)
               console.log('beepOnDeviceDiscover', beepOnDeviceDiscover)
               /**

--- a/src/renderer/util/helpers.ts
+++ b/src/renderer/util/helpers.ts
@@ -86,7 +86,7 @@ export const senseConfigConvert = (config: any): any => {
     return {
       minus: mapMux(entry.Inputs[0]),
       plus: mapMux(entry.Inputs[1]),
-      evokedMode: entry.TdEvokedResponseEnable || false,
+      evokedMode: entry.TdEvokedResponseEnable || 0,
       disabled: !entry.IsEnabled,
       lowPassFilterStage1: mapLpfs1(entry.Lpf1),
       lowPassFilterStage2: mapLpfs2(entry.Lpf2),


### PR DESCRIPTION
A couple of fixes to enhance streaming. Now configs are read from disk when the device connects and when streaming is enabled