### PR TITLE
fix: remove streaming indicator

### DIFF
--- a/src/renderer/components/ConnectionStatusHeader.tsx
+++ b/src/renderer/components/ConnectionStatusHeader.tsx
@@ -34,15 +34,6 @@ const ConnectionStatusHeader: React.FC<ConnectionProp> = ({ status }) => {
         </a>
       </div>
     )
-    case ConnectionState.Streaming: return (
-      <div className='level-item'>
-        <a className='box has-background-success is-flex py-1'>
-          <p className='content'><FontAwesomeIcon className='icon is-small mr-2' icon={faLaptopMedical} />
-            Streaming<FontAwesomeIcon className='icon is-small ml-2' icon={faDotCircle} />
-          </p>
-        </a>
-      </div>
-    )
     case ConnectionState.ConnectedDevice: return (
       <div className='level-item'>
         <a className='box has-background-success is-flex py-1'>

--- a/src/renderer/components/ConnectionStatusHome.tsx
+++ b/src/renderer/components/ConnectionStatusHome.tsx
@@ -134,7 +134,6 @@ const ConnectionStatusHome: React.FC<ConnectionProp> = ({ name, status, prevStat
         connectionJSON.connectINS = 'in-progress'
         break
       }
-      case ConnectionState.Streaming:
       case ConnectionState.ConnectedDevice: {
         connectionJSON.scanCTM = 'success'
         connectionJSON.connectCTM = 'success'

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -42,12 +42,12 @@ const Header: React.FC<HeaderProp> = ({ isRecording, recordingTime }) => {
         {/* Right Side of header */}
         <div className='level-right mt-1'>
           <p className='level-item has-text-white'>L:</p>
-          {state.left.connectionState === ConnectionState.ConnectedDevice || state.left.connectionState === ConnectionState.Streaming
+          {state.left.connectionState >= ConnectionState.ConnectedDevice
             ? <p className='level-item is-size-7 has-text-white'>{leftBatteryPercent}%<Battery percent={leftBatteryPercent} /></p>
             : ''}
           <ConnectionStatusHeader status={state.left.connectionState} />
           <p className='level-item has-text-white'>R:</p>
-          {state.right.connectionState === ConnectionState.ConnectedDevice || state.right.connectionState === ConnectionState.Streaming
+          {state.right.connectionState >= ConnectionState.ConnectedDevice
             ? <p className='level-item is-size-7 has-text-white'>{rightBatteryPercent}%<Battery percent={rightBatteryPercent} /></p>
             : ''}
           <ConnectionStatusHeader status={state.right.connectionState} />

--- a/src/renderer/pages/Playground.tsx
+++ b/src/renderer/pages/Playground.tsx
@@ -14,9 +14,9 @@ interface ProvocationProp {
   isRecording: boolean
 }
 
-const Playground: React.FC<ProvocationProp> = ({ showProvocationTask }) => {
+const Playground: React.FC<ProvocationProp> = ({ showProvocationTask, isRecording }) => {
   const { state } = useOmni()
-  const disabled = state.left.connectionState < ConnectionState.Streaming && state.right.connectionState < ConnectionState.Streaming
+  const disabled = !isRecording
   const launchTask = (appDir: string) => {
     // appDir is the path after AppData/Local/
     (window as any).appService.taskLaunch(appDir)
@@ -24,10 +24,6 @@ const Playground: React.FC<ProvocationProp> = ({ showProvocationTask }) => {
   let warningText
   if (disabled) {
     warningText = 'Warning: At least one INS needs to be recording before you can start a task.'
-  } else if (state.left.connectionState < ConnectionState.Streaming && state.right.connectionState === ConnectionState.Streaming) {
-    warningText = 'Warning: Only your right INS is recording. If you were instructed to complete a task with only one INS, you may proceed.'
-  } else if (state.right.connectionState < ConnectionState.Streaming && state.left.connectionState === ConnectionState.Streaming) {
-    warningText = 'Warning: Only your left INS is recording. If you were instructed to complete a task with only one INS, you may proceed.'
   }
 
   return (

--- a/src/renderer/util/OmniContext.tsx
+++ b/src/renderer/util/OmniContext.tsx
@@ -33,7 +33,6 @@ export enum ConnectionState {
   DiscoveredDevice,
   ConnectingDevice,
   ConnectedDevice,
-  Streaming,
 }
 
 export enum ActionType {
@@ -576,7 +575,7 @@ export const omniReducer = (state: State, action: Action) => {
         switch (streamConfigureStatus) {
           case 'STREAM_CONFIGURE_STATUS_SUCCESS':
             item.previousState = item.connectionState
-            item.connectionState = ConnectionState.Streaming
+            item.connectionState = ConnectionState.ConnectedDevice
             return
           case 'STREAM_CONFIGURE_STATUS_UNKNOWN':
           case 'STREAM_CONFIGURE_STATUS_FAILURE':


### PR DESCRIPTION
The Summit RC+S does not provide a way for us to know if the INS is
streaming or not. Our streaming indicator was a best guess. To prevent
UI confusion, remove the streaming status and leave it as device
connected. As per my conversation with Dave this morning