### PR TITLE
fix: disconnect on application close

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -219,6 +219,17 @@ const App: React.FC = () => {
     return () => clearInterval(recordingInterval)
   }, [isRecording])
 
+  React.useEffect(() => {
+    const handleUnload = async () => {
+      const config = (window as any).appService.config()
+      await (window as any).bridgeManagerService.disconnectFromBridge({ name: config.left.name })
+      await (window as any).bridgeManagerService.disconnectFromBridge({ name: config.right .name })
+    }
+
+    window.addEventListener('unload', handleUnload)
+    return () => window.removeEventListener('unload', handleUnload)
+  })
+
   const recordingClickHandler = async (isRecording: boolean): Promise<void> => {
     const { left, right } = state
     const config = (window as any).appService.config()


### PR DESCRIPTION
This commit adds an event handler to close open connections to RC+S on application unload, which is the renderer process' version of the quit event